### PR TITLE
Relax query-params schema

### DIFF
--- a/src/fnhouse/schemas.clj
+++ b/src/fnhouse/schemas.clj
@@ -60,7 +60,7 @@
    :description String
 
    :request {:uri-args {s/Keyword Schema}
-             :query-params fnk-schema/InputSchema
+             :query-params Schema
              :body (s/maybe Schema)}
    :responses {(s/named s/Int "status code")
                (s/named Schema "response body schema")}

--- a/test/fnhouse/handlers_test.clj
+++ b/test/fnhouse/handlers_test.clj
@@ -43,6 +43,13 @@
     (is (thrown? Exception (handlers/var->handler-info #'$:a$:a$GET)))
     (ns-unmap 'fnhouse.handlers-test '$:a$:a$GET)))
 
+(deftest test-query-params-schema
+  (defnk $q$GET {} [[:request query-params :- (s/either s/Int String)]])
+  (let [handler (handlers/var->handler-info #'$q$GET (constantly {}))]
+    (is (= (-> handler :request :query-params)
+           (s/either s/Int String))))
+  (ns-unmap 'fnhouse.handlers-test '$q$GET))
+
 (deftest nss->handlers-fn-test
   (let [annotation-fn (fn-> meta (select-keys [:auth-level :private]))
         handlers-fn (handlers/nss->handlers-fn {"my-test" 'fnhouse.handlers-test} annotation-fn)


### PR DESCRIPTION
This commit changes the query params schema of handlers to `Schema` to
allow the use of more complex schemas like `s/either`, etc.