### PR TITLE
Explicitly depend on schema 1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :url "https://github.com/Prismatic/fnhouse"
-  :dependencies [[prismatic/plumbing "0.4.3"]]
+  :dependencies [[prismatic/plumbing "0.4.3" :exclusions [prismatic/schema]]
+                 [prismatic/schema "1.0.1"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]]
                    :global-vars {*warn-on-reflection* true}}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}

--- a/src/fnhouse/docs.clj
+++ b/src/fnhouse/docs.clj
@@ -80,7 +80,7 @@
 
 (defrecord LinkedSchema [schema-name]
   s/Schema
-  (walker [this] this)
+  (spec [this] this)
   (explain [this] [[[schema-name]]]))
 
 (declare extract-schemas)


### PR DESCRIPTION
The Schema protocol has changed for anyone who's using the docs namespace.