### PR TITLE
Include error in coercion exception data

### DIFF
--- a/src/fnhouse/middleware.clj
+++ b/src/fnhouse/middleware.clj
@@ -60,6 +60,7 @@
                     {:type :coercion-error
                      :schema schema
                      :data data
+                     :error error
                      :context context}))
             res))))))
 


### PR DESCRIPTION
Seemed like a reasonable thing to have.

Serializing the error data in the exception string strikes me as a bit weird (not to mention having HTML tags in there), and is probably trying to accomplish something that could be handled elsewhere. But that can be a separate change.